### PR TITLE
feat: accounts export

### DIFF
--- a/examples/tackler.toml
+++ b/examples/tackler.toml
@@ -346,7 +346,7 @@ timestamp-style = "seconds"
 ###
 ### This is a list of exports targets to generate.
 ###
-### Valid options are: "equity", "identity"
+### Valid options are: "equity", "identity", "accounts"
 ### CLI: --exports
 targets = [ ]
 
@@ -364,5 +364,11 @@ equity-account = "Equity:Balance"
 ### Identity
 ###
 ### There are no configuration options for identity export
+###
+
+###
+### Accounts Export
+### 
+### There are no configuration options for accounts export
 ###
 ############################################################################

--- a/tackler-cli/src/cli_args.rs
+++ b/tackler-cli/src/cli_args.rs
@@ -403,6 +403,7 @@ pub(crate) struct DefaultModeArgs {
             PossibleValue::new(""),
             PossibleValue::new("identity"),
             PossibleValue::new("equity"),
+            PossibleValue::new("accounts"),
         ]),
         requires("output_directory"),
         requires("output_name"),

--- a/tackler-core/src/config/items.rs
+++ b/tackler-core/src/config/items.rs
@@ -150,10 +150,13 @@ pub enum ExportType {
     #[default]
     Equity,
     Identity,
+    Accounts
+    
 }
 impl ExportType {
     const EQUITY: &'static str = "equity";
     const IDENTITY: &'static str = "identity";
+    const ACCOUNTS: &'static str = "accounts";
 
     /// Export type from string
     ///
@@ -163,6 +166,7 @@ impl ExportType {
         match e {
             Self::EQUITY => Ok(ExportType::Equity),
             Self::IDENTITY => Ok(ExportType::Identity),
+            Self::ACCOUNTS => Ok(ExportType::Accounts),
             _ => Err(format!(
                 "Unknown export type: '{e}'. Valid options are: {}, {}",
                 Self::EQUITY,

--- a/tackler-core/src/export.rs
+++ b/tackler-core/src/export.rs
@@ -14,8 +14,11 @@ use crate::tackler;
 pub use identity_exporter::IdentityExporter;
 use tackler_rs::create_output_file;
 
+pub use accounts_exporter::AccountsExporter;
+
 mod equity_exporter;
 mod identity_exporter;
+mod accounts_exporter;
 
 pub trait Export {
     /// Write export
@@ -63,6 +66,15 @@ pub fn write_exports<ProgW: io::Write + ?Sized>(
                 id_exporter.write_export(settings, &mut out_writer, txn_set)?;
                 if let Some(p) = prog_writer.as_mut() {
                     writeln!(p, "{:>21} : {}", "Identity Export", path)?;
+                }
+            }
+            ExportType::Accounts =>  {
+                let acc_explorer = AccountsExporter {};
+                let (mut out_writer, path) =
+                    create_output_file(output_dir, output_name, "accounts", "txn")?;
+                acc_explorer.write_export(settings, &mut out_writer, txn_set)?;
+                if let Some(p) = prog_writer.as_mut() {
+                    writeln!(p, "{:>21} : {}", "Accounts Export", path)?;
                 }
             }
         }

--- a/tackler-core/src/export/accounts_exporter.rs
+++ b/tackler-core/src/export/accounts_exporter.rs
@@ -57,9 +57,13 @@ impl Export for AccountsExporter {
                 accounts.insert(AccountName::from(&post.acctn.atn.account));
             }
         }
+
+        writeln!(writer, "accounts = [")?;
+
         for i in accounts {
-            writeln!(writer, "{i}")?;
+            writeln!(writer, "   \"{i}\",")?;
         }
+        writeln!(writer, "]")?;
         Ok(())
     }
 }

--- a/tackler-core/src/export/accounts_exporter.rs
+++ b/tackler-core/src/export/accounts_exporter.rs
@@ -1,8 +1,48 @@
-use std::{collections::HashSet, io};
+use std::{cmp::Ordering, collections::BTreeSet, io};
 
 use crate::{export::Export, kernel::Settings, model::TxnSet, tackler};
 
 pub struct AccountsExporter {}
+
+#[derive(PartialEq, Eq, Hash, PartialOrd)]
+struct AccountName<'a>(Vec<&'a str>);
+
+impl<'a> From<&'a String> for AccountName<'a> {
+    fn from(value: &'a String) -> Self {
+        Self(value.split(":").collect())
+    }
+}
+
+impl<'a> From<AccountName<'a>> for String {
+    fn from(value: AccountName<'a>) -> Self {
+        value.0.join(":")
+    }
+}
+
+impl<'a> std::fmt::Display for AccountName<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.join(":"))
+    }
+}
+
+impl<'a> Ord for AccountName<'a> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        for (acc_a, acc_b) in self.0.iter().zip(other.0.iter()) {
+            match acc_a.cmp(acc_b) {
+                Ordering::Equal => continue,
+                ordering => return ordering,
+            }
+        }
+
+        if self.0.len() > other.0.len() {
+            Ordering::Greater
+        } else if self.0.len() < other.0.len() {
+            Ordering::Less
+        } else {
+            Ordering::Equal
+        }
+    }
+}
 
 impl Export for AccountsExporter {
     fn write_export<W: io::Write + ?Sized>(
@@ -11,10 +51,10 @@ impl Export for AccountsExporter {
         writer: &mut W,
         txn_data: &TxnSet<'_>,
     ) -> Result<(), tackler::Error> {
-        let mut accounts: HashSet<String> = HashSet::new();
+        let mut accounts: BTreeSet<AccountName<'_>> = BTreeSet::new();
         for txn in &txn_data.txns {
             for post in txn.posts.iter() {
-                accounts.insert(format!("{}", post.acctn.atn.account));
+                accounts.insert(AccountName::from(&post.acctn.atn.account));
             }
         }
         for i in accounts {

--- a/tackler-core/src/export/accounts_exporter.rs
+++ b/tackler-core/src/export/accounts_exporter.rs
@@ -4,18 +4,17 @@ use crate::{export::Export, kernel::Settings, model::TxnSet, tackler};
 
 pub struct AccountsExporter {}
 
+
+/// Wrapper struct to order account names.
+/// Compares 2 account names piecewise splitting on ':'
+/// 
+/// If `account_name_a` is a prefix of `account_name_b` then `account_name_a < account_name_b` 
 #[derive(PartialEq, Eq, Hash, PartialOrd)]
 struct AccountName<'a>(Vec<&'a str>);
 
 impl<'a> From<&'a String> for AccountName<'a> {
     fn from(value: &'a String) -> Self {
         Self(value.split(":").collect())
-    }
-}
-
-impl<'a> From<AccountName<'a>> for String {
-    fn from(value: AccountName<'a>) -> Self {
-        value.0.join(":")
     }
 }
 

--- a/tackler-core/src/export/accounts_exporter.rs
+++ b/tackler-core/src/export/accounts_exporter.rs
@@ -1,0 +1,25 @@
+use std::{collections::HashSet, io};
+
+use crate::{export::Export, kernel::Settings, model::TxnSet, tackler};
+
+pub struct AccountsExporter {}
+
+impl Export for AccountsExporter {
+    fn write_export<W: io::Write + ?Sized>(
+        &self,
+        _cfg: &Settings,
+        writer: &mut W,
+        txn_data: &TxnSet<'_>,
+    ) -> Result<(), tackler::Error> {
+        let mut accounts: HashSet<String> = HashSet::new();
+        for txn in &txn_data.txns {
+            for post in txn.posts.iter() {
+                accounts.insert(format!("{}", post.acctn.atn.account));
+            }
+        }
+        for i in accounts {
+            writeln!(writer, "{i}")?;
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
Add the ability to export accounts used in a set of transactions using the `--exports accounts` flag.
Running `cargo run --bin tackler --  --output.prefix simple_accounts --output.dir ./simple_accounts --config examples/simple.toml --exports accounts` produces `simple_accounts/simple_accounts.accounts.txn` with the following contents:
```
accounts = [
   "Assets:Bank:Acme_Inc",
   "Assets:Cash",
   "Assets:Visa:4012_8888_8888_1881",
   "Expenses:Food:FastFood",
   "Expenses:Sweets:Candy",
   "Expenses:Sweets:Ice·Cream",
   "Income:Lottery",
]
```